### PR TITLE
Allow week to start on ony day

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
 					<textarea id='eventDescription' onkeyup='changeDescription(event)'></textarea>
 				</div>
 			</div>
+
 			<div class="five columns">
 				<datalist id='fonts'>
 					<option>Georgia</option>
@@ -101,6 +102,16 @@
 					<option>Trebuchet MS</option>
 					<option>Verdana</option>
 				</datalist>
+				<label>Week starts on:</label>
+				<select type='select' id='start-day' onchange='updateMonth()'>
+					<option value="0">Sunday</option>
+					<option value="1">Monday</option>
+					<option value="2">Tuesday</option>
+					<option value="3">Webnesday</option>
+					<option value="4">Thursday</option>
+					<option value="5">Friday</option>
+					<option value="6">Saturday</option>
+				</select>
 				<label>Numeral Font:</label>
 				<input list='fonts' id='numeralFont' onchange='updateNumeralFont()' value="Palatino" />
 				<input type='number' id='numeralFontSize' onchange='updateNumeralSize()' value="14" />

--- a/script.js
+++ b/script.js
@@ -70,6 +70,7 @@ function updateMonth() {
     "use strict";
     var year = document.getElementById('year').value,
         month = document.getElementById('month').value,
+        calendarStartDay = +document.getElementById('start-day').value,
         firstDay = new Date(year, month - 1), // Not sure why -1... chrome bug?
         lastDay = new Date(year, month, -0),
         dateGroup = document.getElementById('datePrototype'),
@@ -92,7 +93,7 @@ function updateMonth() {
     dy = Number(dy);
 
     y = 0;
-    x = dx * firstDay.getDay();
+    x = dx * ((firstDay.getDay() - calendarStartDay + 7) % 7);
 
     for (i = 1; i <= lastDay.getDate(); i += 1) {
 		targetDay = month + "/" + i + "/" + year;


### PR DESCRIPTION
This adds a selection box that lets the user pick which day the week should start on (i.e., what day is represented by the leftmost column in the grid).

This is particular helpful for users from countries like the UK, where calendars are usually drawn with weeks beginning on Mondays (rather than Sundays).